### PR TITLE
Prep for v1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLopt"
 uuid = "76087f3c-5699-56af-9a33-bf431cd00edd"
-version = "1.0.3"
+version = "1.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -14,7 +14,8 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 NLoptMathOptInterfaceExt = ["MathOptInterface"]
 
 [compat]
-MathOptInterface = "1"
+CEnum = "0.5"
+MathOptInterface = "1.25"
 NLopt_jll = "2.7"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NLopt.jl
 
-[![Build Status](https://github.com/JuliaOpt/NLopt.jl/workflows/CI/badge.svg?branch=master)](https://github.com/JuliaOpt/NLopt.jl/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/JuliaOpt/NLopt.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaOpt/NLopt.jl)
+[![Build Status](https://github.com/jump-dev/NLopt.jl/workflows/CI/badge.svg?branch=master)](https://github.com/jump-dev/NLopt.jl/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/jump-dev/NLopt.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jump-dev/NLopt.jl)
 
-[NLopt.jl](https://github.com/JuliaOpt/NLopt.jl) is a wrapper for the
+[NLopt.jl](https://github.com/jump-dev/NLopt.jl) is a wrapper for the
 [NLopt](https://nlopt.readthedocs.io/en/latest/) library for nonlinear
 optimization.
 
@@ -18,7 +18,7 @@ including:
 
 ## License
 
-`NLopt.jl` is licensed under the [MIT License](https://github.com/JuliaOpt/NLopt.jl/blob/master/LICENSE.md).
+`NLopt.jl` is licensed under the [MIT License](https://github.com/jump-dev/NLopt.jl/blob/master/LICENSE.md).
 
 The underlying solver, [stevengj/nlopt](https://github.com/stevengj/nlopt), is
 licensed under the [LGPL v3.0 license](https://github.com/stevengj/nlopt/blob/master/COPYING).


### PR DESCRIPTION
A big diff: https://github.com/JuliaOpt/NLopt.jl/compare/v1.0.3...master

Highlights:

 * Clang used to fully wrap the C API
 * Support for ScalarNonlinearFunction in the MOI wrapper
 * Many many more tests, so that we now have 100% (excluding 1 `@static` line) code coverage
 * All backwards compatible with no breaking changes

Since I've been making quite a few changes, I'll hold off on merging this until I get a few people to check it over.