### PR TITLE
rewrite NLopt 2.9 workaround for NLopt 2.10

### DIFF
--- a/src/NLopt.jl
+++ b/src/NLopt.jl
@@ -8,16 +8,12 @@ module NLopt
 using CEnum: @cenum
 using NLopt_jll: libnlopt
 
-# NLopt@2.9.0 removed the LD_LBFGS_NOCEDAL enum.
-# See https://github.com/stevengj/nlopt/issues/584 for details.
-function _is_version_newer_than_2_9()
-    major, minor, bugfix = Ref{Cint}(), Ref{Cint}(), Ref{Cint}()
-    @ccall libnlopt.nlopt_version(
-        major::Ptr{Cint},
-        minor::Ptr{Cint},
-        bugfix::Ptr{Cint},
-    )::Cvoid
-    return (major[] > 2) || (major[] == 2 && minor[] >= 9)
+############################################################################
+
+function version()
+    major, minor, patch = Ref{Cint}(), Ref{Cint}(), Ref{Cint}()
+    nlopt_version(major, minor, patch)
+    return VersionNumber(major[], minor[], patch[])
 end
 
 include("libnlopt.jl")
@@ -25,7 +21,7 @@ include("libnlopt.jl")
 ############################################################################
 # Mirrors of NLopt's C enum constants:
 
-@static if _is_version_newer_than_2_9()
+@static if v"2.9" ≤ version() < v"2.10"
     @enum Algorithm::Cint begin
         GN_DIRECT = 0
         GN_DIRECT_L
@@ -37,7 +33,7 @@ include("libnlopt.jl")
         GN_ORIG_DIRECT_L
         GD_STOGO
         GD_STOGO_RAND
-        # LD_LBFGS_NOCEDAL
+        # LD_LBFGS_NOCEDAL: temporarily removed in nlopt 2.9 (nlopt#584)
         LD_LBFGS
         LN_PRAXIS
         LD_VAR1
@@ -445,12 +441,6 @@ end
 numevals(o::Opt) = nlopt_get_numevals(o)
 
 ############################################################################
-
-function version()
-    major, minor, patch = Ref{Cint}(), Ref{Cint}(), Ref{Cint}()
-    nlopt_version(major, minor, patch)
-    return VersionNumber(major[], minor[], patch[])
-end
 
 const NLOPT_VERSION = version()
 

--- a/src/libnlopt.jl
+++ b/src/libnlopt.jl
@@ -16,7 +16,11 @@ const nlopt_mfunc = Ptr{Cvoid}
 # typedef void ( * nlopt_precond ) ( unsigned n , const double * x , const double * v , double * vpre , void * data )
 const nlopt_precond = Ptr{Cvoid}
 
-@static if _is_version_newer_than_2_9()
+function nlopt_version(major, minor, bugfix)
+    ccall((:nlopt_version, libnlopt), Cvoid, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), major, minor, bugfix)
+end
+
+@static if v"2.9" ≤ version() < v"2.10"
     @cenum nlopt_algorithm::UInt32 begin
         NLOPT_GN_DIRECT = 0
         NLOPT_GN_DIRECT_L
@@ -156,10 +160,6 @@ end
 
 function nlopt_srand_time()
     ccall((:nlopt_srand_time, libnlopt), Cvoid, ())
-end
-
-function nlopt_version(major, minor, bugfix)
-    ccall((:nlopt_version, libnlopt), Cvoid, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), major, minor, bugfix)
 end
 
 mutable struct nlopt_opt_s end

--- a/test/C_API.jl
+++ b/test/C_API.jl
@@ -567,7 +567,7 @@ function test_algorithm_name()
     sol = "Limited-memory BFGS (L-BFGS) (local, derivative-based)"
     @test algorithm_name(algorithm) == sol
     @test algorithm_name(:LD_LBFGS) == sol
-    if NLopt._is_version_newer_than_2_9()
+    if v"2.9" ≤ NLopt.version() < v"2.10"
         @test algorithm_name(10) == sol
     else
         @test algorithm_name(11) == sol


### PR DESCRIPTION
#251 is only needed for 2.9, and is longer needed in NLopt 2.10 (https://github.com/stevengj/nlopt/pull/587 — which should be out soon on Yggdrasil: https://github.com/JuliaPackaging/Yggdrasil/pull/10431).